### PR TITLE
Fix mod_ssl on cent6/2.4, remove order statements

### DIFF
--- a/apache/map.jinja
+++ b/apache/map.jinja
@@ -56,6 +56,7 @@
         'mod_wsgi': 'mod_wsgi',
         'conf_mod_wsgi': '/etc/httpd/conf.d/wsgi.conf',
         'mod_php5': 'php',
+        'mod_ssl': 'mod_ssl',
         'mod_pagespeed_source': 'https://dl-ssl.google.com/dl/linux/direct/mod-pagespeed-stable_current_x86_64.rpm',
 
         'vhostdir': '/etc/httpd/vhosts.d',

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -16,9 +16,6 @@ a2enmod mod_ssl:
       - module: apache-restart
 
 {% elif grains['os_family']=="RedHat" %}
-
-include:
-  - apache
   
 mod_ssl:
   pkg.installed:

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -17,6 +17,9 @@ a2enmod mod_ssl:
 
 {% elif grains['os_family']=="RedHat" %}
 
+include:
+  - apache
+  
 mod_ssl:
   pkg.installed:
     - name: {{ apache.mod_ssl }}

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -19,7 +19,7 @@ a2enmod mod_ssl:
 
 mod_ssl:
   pkg.installed:
-    - name: {{ apache.mod_ssl_pkg }}
+    - name: {{ apache.mod_ssl }}
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/mod_ssl.sls
+++ b/apache/mod_ssl.sls
@@ -19,6 +19,7 @@ a2enmod mod_ssl:
 
 mod_ssl:
   pkg.installed:
+    - name: {{ apache.mod_ssl_pkg }}
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -57,6 +57,17 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ m
 include:
   - apache
  
+{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
+a2dismod -f {{ module }}:
+  cmd.run:
+    - onlyif: egrep "^APACHE_MODULES=" /etc/sysconfig/apache2 | grep {{ module }}
+    - order: 225
+    - require:
+      - pkg: apache
+    - watch_in:
+      - module: apache-restart
+{% endfor %}
+
 {% for module in salt['pillar.get']('apache:modules:enabled', []) %}
 a2enmod {{ module }}:
   cmd.run:
@@ -68,15 +79,5 @@ a2enmod {{ module }}:
       - module: apache-restart
 {% endfor %}
 
-{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
-a2dismod -f {{ module }}:
-  cmd.run:
-    - onlyif: egrep "^APACHE_MODULES=" /etc/sysconfig/apache2 | grep {{ module }}
-    - order: 225
-    - require:
-      - pkg: apache
-    - watch_in:
-      - module: apache-restart
-{% endfor %}
 
 {% endif %}

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -34,7 +34,6 @@ include:
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ module }}_module\)/#\1/g' {} \;:
   cmd.run:
     - onlyif: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
-    - order: 225
     - require:
       - pkg: apache
     - watch_in:
@@ -45,7 +44,6 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ m
 find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule.{{ module }}_module\)/\2/g' {} \;:
   cmd.run:
     - unless: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
-    - order: 225
     - require:
       - pkg: apache
     - watch_in:

--- a/apache/modules.sls
+++ b/apache/modules.sls
@@ -29,11 +29,11 @@ a2dismod -f {{ module }}:
 
 include:
   - apache
- 
-{% for module in salt['pillar.get']('apache:modules:enabled', []) %}
-find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule.{{ module }}_module\)/\2/g' {} \;:
+
+{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
+find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ module }}_module\)/#\1/g' {} \;:
   cmd.run:
-    - unless: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
+    - onlyif: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
     - order: 225
     - require:
       - pkg: apache
@@ -41,10 +41,10 @@ find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule
       - module: apache-restart
 {% endfor %}
 
-{% for module in salt['pillar.get']('apache:modules:disabled', []) %}
-find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^\s*LoadModule.{{ module }}_module\)/#\1/g' {} \;:
+{% for module in salt['pillar.get']('apache:modules:enabled', []) %}
+find /etc/httpd/ -name '*.conf' -type f -exec sed -i -e 's/\(^#\)\(\s*LoadModule.{{ module }}_module\)/\2/g' {} \;:
   cmd.run:
-    - onlyif: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
+    - unless: httpd -M 2> /dev/null | grep "[[:space:]]{{ module }}_module"
     - order: 225
     - require:
       - pkg: apache


### PR DESCRIPTION
reorder the disable/enable of modules so that MPM module can be swapped without ending up with 2 enabled at once.

Allow specifying name of mod_ssl package for use with IUS repository

